### PR TITLE
Accessibility fixes

### DIFF
--- a/src/select/directives.js
+++ b/src/select/directives.js
@@ -1,5 +1,5 @@
 angular.module('oi.multiselect')
-    
+
 .directive('oiMultiselect', ['$document', '$q', '$timeout', '$parse', '$interpolate', '$injector', '$filter', 'oiUtils', 'oiMultiselect', function($document, $q, $timeout, $parse, $interpolate, $injector, $filter, oiUtils, oiMultiselect) {
     var NG_OPTIONS_REGEXP = /^\s*([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+group\s+by\s+([\s\S]+?))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?$/,
         VALUES_REGEXP     = /([^\(\)\s\|\s]*)\s*(\(.*\))?\s*(\|?\s*.+)?/;
@@ -270,6 +270,7 @@ angular.module('oi.multiselect')
 
                         case 13: /* enter */
                             saveOn('enter');
+                            event.preventDefault(); // Prevent the event from bubbling up as it might otherwise cause a form submission
                             break;
                         case 9: /* tab */
                             blurHandler();

--- a/template/multiselect/template.html
+++ b/template/multiselect/template.html
@@ -1,10 +1,11 @@
-<div class="multiselect-search" ng-class="{open: isOpen, focused: isFocused, loading: showLoader}" ng-click="setFocus($event)">
+<div class="multiselect-search" ng-class="{open: isOpen, focused: isFocused, loading: showLoader}" ng-click="setFocus($event)" tabindex="-1">
     <ul class="multiselect-search-list">
         <li class="btn btn-default btn-xs multiselect-search-list-item multiselect-search-list-item_selection"
             ng-repeat="item in output track by $index"
             ng-class="{focused: backspaceFocus && $last}"
             ng-click="removeItem($index)"
-            ng-bind-html="getSearchLabel(item)"></li>
+            ng-bind-html="getSearchLabel(item)"
+            tabindex="-1"></li>
         <li class="multiselect-search-list-item multiselect-search-list-item_input"><input autocomplete="off"
                                                                                            ng-model="query"
                                                                                            ng-style="{'width': inputWidth + 'px'}"
@@ -13,7 +14,7 @@
         <li class="multiselect-search-list-item multiselect-search-list-item_loader" ng-show="showLoader"></li>
     </ul>
 </div>
-<div class="multiselect-dropdown" ng-show="isOpen" ng-click="setFocus($event)">
+<div class="multiselect-dropdown" ng-show="isOpen" ng-click="setFocus($event)" tabindex="-1">
     <ul ng-if="isOpen" class="multiselect-dropdown-optgroup" ng-repeat="(group, options) in groups">
         <div class="multiselect-dropdown-optgroup-header"
             ng-if="group && options.length"


### PR DESCRIPTION
Two minor accessibility fixes:
 - When oi.multiselect is used in combination with ngAria, the tab ordering gets messed up. By adding tabindex=“-1” to those elements that don’t need to be tabbable, that can be avoided.
 - When selecting a user through the keyboard, don’t bubble the enter event as it causes a form submission when oi.multiselect is embedded in a form

Loving the component so far!